### PR TITLE
Автопубликация релиза

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Publish package to VSCode Marketplace
+
+on:
+    release:
+        types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '16'
+      - run: npm install
+      - name: Build package
+        run: npx vsce package
+      - name: Upload vsix to release
+        uses: AButler/upload-release-assets@v1.0
+        with:
+            files: '*.vsix'
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: lannonbr/vsce-action@master
+        if: github.event.release.prerelease == false
+        with:
+          args: "publish -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: '16'
       - run: npm install
+      - run: npm install -g vsce
       - name: Build package
         run: npx vsce package
       - name: Upload vsix to release


### PR DESCRIPTION
Closes #10

Задача, собирающая vsix, прикладывающая его в Releases и делающая публикацию в marketplace, если релиз не помечен как prerelease.

Срабатывает на создание нового release на гитхабе.

Для публикации в маркетплейс нужно сохранить в secrets